### PR TITLE
fix some formatting issues for registry.json instructions

### DIFF
--- a/_includes/configure-registry-json.md
+++ b/_includes/configure-registry-json.md
@@ -2,50 +2,68 @@
 
 ## Create a registry.json file
 
-When creating a `registry.json` file, ensure that the developer is a member of at least one organization in Docker Hub. If the `registry.json` file matches at least one organization the developer is a member of, they can sign in to Docker Desktop and access all their organizations.
+When creating a `registry.json` file, ensure that the developer is a member of
+at least one organization in Docker Hub. If the `registry.json` file matches at
+least one organization the developer is a member of, they can sign in to Docker
+Desktop and access all their organizations.
 
 ### Windows
 
 On Windows, run the following command in a terminal to install Docker Desktop:
 
-`"Docker Desktop Installer.exe" install`
+```console
+C:\Users\Admin> "Docker Desktop Installer.exe" install
+```
 
 If you’re using PowerShell, you should run it as:
 
-`Start-Process '.\win\build\Docker Desktop Installer.exe' -Wait install`
+```console
+PS> Start-Process '.\win\build\Docker Desktop Installer.exe' -Wait install
+```
 
 If using the Windows Command Prompt:
 
-`start /w "" "Docker Desktop Installer.exe" install`
+```console
+C:\Users\Admin> start /w "" "Docker Desktop Installer.exe" install
+```
 
 The `install` command accepts the following flag:
 
 `--allowed-org=<org name>`
 
-This requires the user to sign in and be part of the specified Docker Hub organization when running the application. For example:
+This requires the user to sign in and be part of the specified Docker Hub organization
+when running the application. For example:
 
- `Docker Desktop Installer.exe" install --allowed-org=acmeinc`
+```console
+C:\Users\Admin> "Docker Desktop Installer.exe" install --allowed-org=acmeinc
+```
 
- This creates the registry.json file at `C:\ProgramData\DockerDesktop\registry.json` and includes the organization information the user belongs to. Make sure this file can't be edited by the individual developer, only by the administrator.
+This creates the `registry.json` file at `C:\ProgramData\DockerDesktop\registry.json` 
+and includes the organization information the user belongs to. Make sure this file
+can't be edited by the individual developer, only by the administrator.
 
 ### Mac
 
-After downloading `Docker.dmg`, run the following commands in a terminal to install Docker Desktop in the Applications folder:
+After downloading `Docker.dmg`, run the following commands in a terminal to install
+Docker Desktop in the Applications folder:
 
-
-
-```
-sudo hdiutil attach Docker.dmg
-sudo /Volumes/Docker/Docker.app/Contents/MacOS/install
-sudo hdiutil detach /Volumes/Docker
+```console
+$ sudo hdiutil attach Docker.dmg
+$ sudo /Volumes/Docker/Docker.app/Contents/MacOS/install
+$ sudo hdiutil detach /Volumes/Docker
 ```
 
 The `install` command accepts the following flags:
 
 `--allowed-org=<org name>`
 
-This requires the user to sign in and be part of the specified Docker Hub organization when running the application. For example:
+This requires the user to sign in and be part of the specified Docker Hub
+organization when running the application. For example:
 
- `sudo hdiutil attach Docker.dmg --allowed-org=acmeinc`
+```console
+$ sudo hdiutil attach Docker.dmg --allowed-org=acmeinc
+```
 
-This creates the registry.json file at `C:\ProgramData\DockerDesktop\registry.json` and includes the organization information the user belongs to. Make sure this file can't be edited by the individual developer, only by the administrator.
+This creates the `registry.json` file at `/Library/Application Support/com.docker.docker/registry.json`
+and includes the organization information the user belongs to. Make sure this file
+can't be edited by the individual developer, only by the administrator.

--- a/docker-hub/configure-sign-in.md
+++ b/docker-hub/configure-sign-in.md
@@ -4,7 +4,11 @@ keywords: authentication, registry.json, configure,
 title: Configure registry.json to enforce sign in
 ---
 
-The `registry.json` file is a configuration file that allows administrators to specify the Docker organization the user must belong to and ensure that the organization’s settings apply to the user’s session. The Docker Desktop installer can create this file and deploy it to the users’ machines as part of the installation process.
+The `registry.json` file is a configuration file that allows administrators to
+specify the Docker organization the user must belong to and ensure that the
+organization’s settings apply to the user’s session. The Docker Desktop installer
+can create this file and deploy it to the users’ machines as part of the installation
+process.
 
 After you deploy a `registry.json` file to a user’s machine, it prompts the user to sign into Docker Desktop. If a user doesn’t sign in, or tries to sign in using a different organization, other than the organization listed in the `registry.json` file, they will be denied access to Docker Desktop.
 Deploying a `registry.json` file and forcing users to authenticate offers the following benefits:


### PR DESCRIPTION
- use `console` blocks for command-line examples
- use different prompts for "powershell" and "non-powershell" examples
- fix path of registry.json on macOS
- wrap some of the lines to ~80 chars

Before this:

<img width="1014" alt="Screenshot 2022-04-19 at 11 41 25" src="https://user-images.githubusercontent.com/1804568/163978044-9624b418-4ef0-4143-89ad-e6f547f4bfa1.png">


After this:

<img width="1009" alt="Screenshot 2022-04-19 at 11 46 53" src="https://user-images.githubusercontent.com/1804568/163978132-0722c31c-44ee-4f6d-a6e1-bcb947cd33ce.png">
